### PR TITLE
fixed self execution of commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,9 +203,8 @@ function forEachCommand(commands, message) {
 }
 // Message Create Event
 client.on('messageCreate', async message => {
-  if (message.author.bot) {
-    return
-  }
+  if (message.author.bot) return;
+  if (message.author.id === client.user.id) return;
   forEachCommand(Commands, message)
   
 })


### PR DESCRIPTION
This pull request prevents the bot from accidentally ratelimiting itself by excluding the user itself from the people who can run the commands.
![self-command](https://user-images.githubusercontent.com/29303616/180300831-f72f70b4-52eb-47d1-8073-03a017e72d69.png)
